### PR TITLE
Only index HTML pages

### DIFF
--- a/lib/drumknott/refresh.rb
+++ b/lib/drumknott/refresh.rb
@@ -71,7 +71,12 @@ class Drumknott::Refresh
 
   def update
     output.call "Posts", site.posts.docs
-    output.call "Pages", site.pages if include_pages?
+    return unless include_pages?
+
+    output.call(
+      "Pages",
+      site.pages.select { |page| page.html? || page.url.end_with?("/") }
+    )
   end
 
   def update_document(document)


### PR DESCRIPTION
This prevents indexing css files, rss feeds and other things you
probably don't want to have in your index

Also prevents indexing sourcemaps which leads to errors due to their
binary content

I had a ton of unrelated rubocop errors locally, not sure what's up with that.

fixes #1